### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/OralEye/OralEye-API-Issue-Tracker.png?label=ready&title=Ready)](https://waffle.io/OralEye/OralEye-API-Issue-Tracker)
 # OralEye-API
 Issue tracking for OralEye API


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/OralEye/OralEye-API-Issue-Tracker

This was requested by a real person (user mauricegavin) on waffle.io, we're not trying to spam you.
